### PR TITLE
fix: add more descriptive error when offline

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -40,5 +40,5 @@ function outputFormatter (prs) {
 }
 
 function errorFormatter (err) {
-  console.log('Error: ', err.toString())
+  console.log('Error: ', err.message)
 }

--- a/lib/pr.js
+++ b/lib/pr.js
@@ -15,4 +15,12 @@ module.exports = function getPullRequests (user, repo, labels) {
     .then((resp) => {
       return resp.data.filter((repo) => repo.pull_request)
     })
+    .catch((err) => {
+      // this kinda sucks because github-api gives a
+      // "cannot read property 'status' of undefined" when network is
+      // unreachable, so we have to catch that TypeError.
+      if (err instanceof TypeError) {
+        throw new Error('Could not contact Github. Are you offline?')
+      } else { throw err }
+    })
 }


### PR DESCRIPTION
The github-api module throws a TypeError "cannot read property 'status'
of undefined" error message. This commit catches that specific error and
throws a new Error with a more descriptive message that we can show the
user.